### PR TITLE
Fix array(string).optional error

### DIFF
--- a/src/Repository.spec.ts
+++ b/src/Repository.spec.ts
@@ -144,6 +144,7 @@ describe('smData.repository', () => {
       properties: {
         id: smData.string,
         people: smData.array(smData.string),
+        peopleOptional: smData.array(smData.string).optional,
       },
     });
 
@@ -151,11 +152,13 @@ describe('smData.repository', () => {
       id: 'mock-id',
       type: 'mockNodeType',
       people: `__JSON__["joe", "bob"]`,
+      peopleOptional: `__JSON__["user1", "user2"]`,
     } as { id: string });
 
     const DO = repository.byId('mock-id');
 
     expect(DO.people).toEqual(['joe', 'bob']);
+    expect(DO.peopleOptional).toEqual(['user1', 'user2']);
   });
 
   it('converts data received in old object format to a regular object', () => {

--- a/src/Repository.ts
+++ b/src/Repository.ts
@@ -153,7 +153,7 @@ export function RepositoryFactory<
           const smDataType =
             typeof receivedDataValue === 'function'
               ? ((receivedDataValue as any)._default as ISMData).type
-              : (receivedData as ISMData).type;
+              : receivedDataValue.type;
 
           return (
             smDataType === SM_DATA_TYPES.array ||


### PR DESCRIPTION
Problem:
Throws an error when querying data and some property is a ``array(string).optional``(_Everything works if it's not optional an optional array_)

Node:
```
const accountabilityChartSeatProperties = {
  seatSpecificRoles: array(string).optional,
  .....
}
```

Query:
```
const { data } = useSubscription({
    authenticatedUser: useAuthenticatedOrgUserQuery({
      map: ({ org }) => ({
        org: org({
          map: ({ accountabilityChart }) => ({
            accountabilityChart: accountabilityChart({
              map: ({ seats }) => ({
                seats: seats({
                  map: ({ seatSpecificRoles }) => ({
                    seatSpecificRoles,
                  }),
                }),
              }),
            }),
          }),
        }),
      }),
    }),
  })
```

<img width="1357" alt="Screen Shot 2022-03-16 at 4 51 38 PM" src="https://user-images.githubusercontent.com/52786162/158552371-cd9f6fe3-ff62-40d0-afbf-6ac86dacbfbb.png">
