### PR TITLE
Infer ISMJS

### DIFF
--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -1,5 +1,9 @@
+import { createDOFactory } from './DO';
+import { createDOProxyGenerator } from './DOProxyGenerator';
 import { SM_RELATIONAL_TYPES } from './smDataTypes';
-import { IPendingTransaction, ITransactionContext } from './transaction/transaction';
+import { generateQuerier, generateSubscriber } from './smQueriers';
+import { createSMQueryManager } from './SMQueryManager';
+import { createTransaction } from './transaction/transaction';
 export declare type BOmit<T, K extends keyof T> = T extends any ? Omit<T, K> : never;
 export declare type Maybe<T> = T | null;
 export declare type SMDataDefaultFn = (_default: any) => ISMData;
@@ -101,34 +105,15 @@ export interface ISMJS {
         token: string;
     }): void;
     clearTokens(): void;
-    query<TQueryDefinitions extends QueryDefinitions>(queryDefinition: TQueryDefinitions, opts?: QueryOpts<TQueryDefinitions>): Promise<QueryReturn<TQueryDefinitions>>;
-    subscribe<TQueryDefinitions extends QueryDefinitions, TSubscriptionOpts extends SubscriptionOpts<TQueryDefinitions>>(queryDefinitions: TQueryDefinitions, opts: TSubscriptionOpts): Promise<TSubscriptionOpts extends {
-        skipInitialQuery: true;
-    } ? SubscriptionMeta : {
-        data: QueryDataReturn<TQueryDefinitions>;
-    } & SubscriptionMeta>;
-    def<TNodeData extends Record<string, ISMData | SMDataDefaultFn>, TNodeComputedData extends Record<string, any>, TNodeRelationalData extends NodeRelationalQueryBuilderRecord, TNodeMutations extends Record<string, NodeMutationFn>>(def: NodeDefArgs<TNodeData, TNodeComputedData, TNodeRelationalData, TNodeMutations>): ISMNode<TNodeData, TNodeComputedData, TNodeRelationalData, TNodeMutations>;
-    transaction(callback: ((context: ITransactionContext) => void | Promise<void>) | Array<IPendingTransaction>, opts?: {
-        tokenName: string;
-    }): IPendingTransaction;
+    query: ReturnType<typeof generateQuerier>;
+    subscribe: ReturnType<typeof generateSubscriber>;
+    transaction: ReturnType<typeof createTransaction>;
     gqlClient: ISMGQLClient;
     plugins: Array<SMPlugin> | undefined;
-    DOProxyGenerator<TNodeData extends Record<string, ISMData | SMDataDefaultFn>, TNodeComputedData extends Record<string, any>, TRelationalResults extends Record<string, Array<IDOProxy> | IDOProxy>>(opts: {
-        node: ISMNode<TNodeData, TNodeComputedData>;
-        queryId: string;
-        do: NodeDO;
-        allPropertiesQueried: Array<string>;
-        relationalResults: Maybe<TRelationalResults>;
-        relationalQueries: Maybe<Record<string, RelationalQueryRecordEntry>>;
-    }): NodeDO & TRelationalResults & IDOProxy;
-    DOFactory<TNodeData extends Record<string, ISMData | SMDataDefaultFn>, TNodeComputedData extends Record<string, any>, TNodeRelationalData extends NodeRelationalQueryBuilderRecord, TNodeMutations extends Record<string, NodeMutationFn>, TDOClass = new (initialData?: Record<string, any>) => NodeDO>(node: {
-        type: string;
-        properties: TNodeData;
-        computed?: NodeComputedFns<TNodeData, TNodeComputedData>;
-        relational?: NodeRelationalFns<TNodeRelationalData>;
-        mutations?: TNodeMutations;
-    }): TDOClass;
-    SMQueryManager: new (queryRecord: QueryRecord) => ISMQueryManager;
+    DOProxyGenerator: ReturnType<typeof createDOProxyGenerator>;
+    DOFactory: ReturnType<typeof createDOFactory>;
+    SMQueryManager: ReturnType<typeof createSMQueryManager>;
+    def<TNodeData extends Record<string, ISMData | SMDataDefaultFn>, TNodeComputedData extends Record<string, any>, TNodeRelationalData extends NodeRelationalQueryBuilderRecord, TNodeMutations extends Record<string, NodeMutationFn>>(def: NodeDefArgs<TNodeData, TNodeComputedData, TNodeRelationalData, TNodeMutations>): ISMNode<TNodeData, TNodeComputedData, TNodeRelationalData, TNodeMutations>;
 }
 export declare type NodeDefArgs<TNodeData extends Record<string, ISMData | SMDataDefaultFn>, TNodeComputedData extends Record<string, any>, TNodeRelationalData extends NodeRelationalQueryBuilderRecord, TNodeMutations extends Record<string, /*NodeMutationFn<TNodeData, any>*/ NodeMutationFn>> = {
     type: string;


### PR DESCRIPTION
When I modified tokenName to be optional for transaction in my last commit, this didn't carry over to the ISMJS interface which had the type of `transaction` duplicated. In this change I use ReturnType inferrence to generate the ISMJS interface based on the actual functions being used